### PR TITLE
Side-safety docs

### DIFF
--- a/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
+++ b/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
@@ -66,7 +66,7 @@ package net.neoforged.api.distmarker;
  *     // Returns false if executed on the server. Will never crash.
  *     public static boolean isClientSingleplayer()
  *     {
- *         if(currentDist.isClient())
+ *         if (currentDist.isClient())
  *         {
  *             return ClientBouncer.isClientSingleplayer();
  *         }
@@ -86,7 +86,7 @@ package net.neoforged.api.distmarker;
  * <li>If running on {@link Dist#CLIENT}, then {@code ClientBouncer.isClientSingleplayer} will be verified.</li>
  * </ol>
  * The final step causes the verifier to resolve a reference to {@code Minecraft}, which is client-only code.
- * If this step happend on {@link Dist#DEDICATED_SERVER} (i.e. if the dist check were omitted), the game would crash.
+ * If this step happened on {@link Dist#DEDICATED_SERVER} (i.e., if the dist check were omitted), the game would crash.
  * 
  * @apiNote How to access the current Dist will depend on the project. When using FML, it is in FMLEnvironment.dist
  */

--- a/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
+++ b/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
@@ -20,7 +20,7 @@
 package net.neoforged.api.distmarker;
 
 /**
- * A distribution of the minecraft game. There are two common distributions, and though
+ * A physical distribution of Minecraft. There are two common distributions, and though
  * much code is common between them, there are some specific pieces that are only present
  * in one or the other.
  * <ul>
@@ -29,6 +29,48 @@ package net.neoforged.api.distmarker;
  *     <li>{@link #DEDICATED_SERVER} is the <em>dedicated server</em> distribution,
  *     it contains a server, which can simulate the world and communicates via network.</li>
  * </ul>
+ * <p>
+ * When working with Dist-specific code, it is important to guard invocations such that
+ * classes invalid for the current Dist are not loaded.
+ * <p>
+ * This is done by obeying the following rules:<br>
+ * 1. All Dist-specific code must go in a separate class.<br>
+ * 2. All accesses to the Dist-specific class must be guarded by a Dist check.
+ * <p>
+ * Following these rules ensures that a Dist-induced classloading error will never occur.
+ * <p>
+ * An example of these rules in action is shown below:
+ * <p>
+ * <code><pre>
+ * // Class which accesses code that is only present in Dist.CLIENT
+ * public class ClientOnlyThings
+ * {
+ *     public static boolean isClientSingleplayer()
+ *     {
+ *         return Minecraft.getInstance().isSingleplayer();
+ *     }
+ * }
+ * 
+ * // Class which is loaded on both Dists.
+ * public class SharedClass 
+ * {
+ *     // Returns true if the client is playing singleplayer.
+ *     // Returns false if executed on the server (will never crash).
+ *     public static boolean isClientSingleplayer()
+ *     {
+ *         if(currentDist.isClient())
+ *         {
+ *             return ClientOnlyThings.isClientSingleplayer();
+ *         }
+ *         return false;
+ *     }
+ * }
+ * </pre></code>
+ * 
+ * In this example, any code can now call <code>SharedClass.isClientSingleplayer()</code> without guarding.<br>
+ * However, only code that is specific to Dist.CLIENT may call <code>ClientOnlyThings.isClientSingleplayer()<code>.
+ * 
+ * @apiNote How to access the current Dist will depend on the project. When using FML, it is in FMLEnvironment.dist
  */
 public enum Dist {
 

--- a/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
+++ b/src/forgeAPI/java/net/neoforged/api/distmarker/Dist.java
@@ -77,18 +77,11 @@ package net.neoforged.api.distmarker;
  * 
  * In this example, any code can now call {@code SharedClass.isClientSingleplayer()} without guarding.
  * <p>
- * The specifics of why this works relies on how the class verifier operates. When the shared method 
- * is invoked for the first time, the following steps occur:
- * <ol>
- * <li>The class {@code SharedClass} is loaded, if it was not previously accessed</li>
- * <li>The method {@code SharedClass.isClientSingleplayer} is loaded and verified.</li>
- * <li>It is checked that {@code ClientBouncer} exists, but the content of its methods are not yet verified.</li>
- * <li>If running on {@link Dist#CLIENT}, then {@code ClientBouncer.isClientSingleplayer} will be verified.</li>
- * </ol>
- * The final step causes the verifier to resolve a reference to {@code Minecraft}, which is client-only code.
- * If this step happened on {@link Dist#DEDICATED_SERVER} (i.e., if the dist check were omitted), the game would crash.
+ * The specifics of why this works are too complicated to be written here.
+ * <p>
+ * Additionally, this process can be extrapolated for use with any optional dependency.
  * 
- * @apiNote How to access the current Dist will depend on the project. When using FML, it is in FMLEnvironment.dist
+ * @apiNote How to access the current Dist will depend on the project. When using FancyModLoader, it is in FMLEnvironment.dist
  */
 public enum Dist {
 


### PR DESCRIPTION
This PR adds javadocs to `Dist` explaining best practices with examples on how to prevent Dist-related classloading errors.

Resurrection of https://github.com/MinecraftForge/MergeTool/pull/8

Supports the goal of removing `DistExecutor` and informing modders of how to properly guard code.