### PR TITLE
Use capabilities in publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,21 @@ sourceSets {
 }
 
 java {
+    registerFeature('cpw') {
+        usingSourceSet sourceSets.cpwFML
+        capability(project.group, "mergetool-cpw", project.version.toString())
+    }
+    registerFeature('forge') {
+        usingSourceSet sourceSets.forgeFML
+        capability(project.group, "mergetool-forge", project.version.toString())
+    }
+    registerFeature('api') {
+        usingSourceSet sourceSets.forgeAPI
+        capability(project.group, "mergetool-api", project.version.toString())
+    }
+}
+
+java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(8)
     }
@@ -68,20 +83,8 @@ tasks.named('sourcesJar', Jar).configure {
     from sourceSets.forgeAPI.allSource
 }
 
-tasks.register('cpwFML', Jar) {
-    archiveClassifier = 'cpw'
-    from sourceSets.cpwFML.output
-}
-
-tasks.register('forgeFML', Jar) {
-    archiveClassifier = 'forge'
-    from sourceSets.forgeFML.output
-}
-
-tasks.register('forgeAPI', Jar) {
+tasks.named('forgeAPIJar', Jar) {
     manifest.attributes('Automatic-Module-Name': 'net.neoforged.mergetool.api')
-    archiveClassifier = 'api'
-    from sourceSets.forgeAPI.output
 }
 
 dependencies {
@@ -96,19 +99,23 @@ dependencies {
     implementation sourceSets.forgeAPI.output
 }
 
-artifacts {
-    archives shadowJar
-    archives cpwFML
-    archives forgeFML
-    archives forgeAPI
+[
+        configurations.runtimeElements,
+        configurations.apiElements,
+        configurations.shadowRuntimeElements,
+        configurations.sourcesElements
+].each {
+    it.outgoing {
+        capability("${project.group}:mergetool:${project.version}")
+        capability("${project.group}:mergetool-cpw:${project.version}")
+        capability("${project.group}:mergetool-api:${project.version}")
+        capability("${project.group}:mergetool-forge:${project.version}")
+    }
 }
 
 publishing {
     publications.register('mavenJava', MavenPublication) {
         from components.java
-        artifact cpwFML
-        artifact forgeFML
-        artifact forgeAPI
 
         artifactId = 'mergetool'
 


### PR DESCRIPTION
MergeTool publishes 4 different artifacts, some of which contain the same features as others; this makes it a perfect place to use gradle feature variants and capabilities to mark which artifacts contain what in the published metadata. Consumers that depend on the library by its capabilities will be able to ensure that they do not end up with duplicates of any piece of the library at the dependency resolution step; as the classifiers are unchanged, consumers depending on the library via classifier (all current ones) will be unaffected.